### PR TITLE
feat: add GitHub login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,7 @@ dependencies = [
  "octocrab",
  "open",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -315,6 +322,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -389,6 +406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +451,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -577,6 +618,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +697,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -676,6 +737,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -891,6 +968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "iri-string"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1203,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1233,6 +1339,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,9 +1372,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
@@ -1472,6 +1604,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1705,16 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1587,12 +1772,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1793,6 +1991,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1803,6 +2004,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1923,6 +2145,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2225,6 +2457,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2295,6 +2550,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "6.0.0"
 url = "2.5.4"
 regex = "1.11.1"
 base64 = "0.22.1"
+reqwest = { version = "0.12.12", features = ["json"] }
 
 [lints.clippy]
 complexity = { level = "deny", priority = -1 }

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -1,0 +1,104 @@
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::{fs, time::Duration};
+use tracing::instrument;
+
+#[instrument(skip(client_id))]
+pub async fn login(client_id: &str) -> eyre::Result<String> {
+    println!("BountyBot CLI is open source. Check https://github.com/ghbountybot/cli to see how we use your GitHub token.\n");
+
+    let multi = MultiProgress::new();
+    let spinner_style = ProgressStyle::with_template("{spinner:.green} {msg:.bold.dim}")
+        .unwrap()
+        .tick_chars("⣾⣽⣻⢿⡿⣟⣯⣷");
+
+    let status_pb = multi.add(ProgressBar::new_spinner());
+    status_pb.set_style(spinner_style);
+    status_pb.enable_steady_tick(Duration::from_millis(80));
+
+    status_pb.set_message("Requesting device code...");
+
+    // Request device code
+    let client = reqwest::Client::new();
+    let device_code_resp = client
+        .post("https://github.com/login/device/code")
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", client_id),
+            ("scope", "repo"),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await?;
+
+    let device_code = device_code_resp["device_code"].as_str().unwrap();
+    let user_code = device_code_resp["user_code"].as_str().unwrap();
+    let verification_uri = device_code_resp["verification_uri"].as_str().unwrap();
+    let interval = device_code_resp["interval"].as_u64().unwrap_or(5);
+
+    println!("\nPlease visit: {verification_uri}");
+    println!("And enter code: {user_code}\n");
+
+    // Try to open the browser but ignore errors
+    let _ = open::that(verification_uri);
+
+    status_pb.set_message("Waiting for device authorization...");
+
+    // Poll for token
+    loop {
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+
+        let token_resp = client
+            .post("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", client_id),
+                ("device_code", device_code),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?;
+
+        if let Some(error) = token_resp["error"].as_str() {
+            match error {
+                "authorization_pending" => continue,
+                "slow_down" => {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    continue;
+                }
+                "expired_token" => {
+                    status_pb.finish_with_message("❌ Device code expired. Please try again.");
+                    return Err(eyre::eyre!("Device code expired"));
+                }
+                "access_denied" => {
+                    status_pb.finish_with_message("❌ Authorization denied by user.");
+                    return Err(eyre::eyre!("Authorization denied"));
+                }
+                _ => {
+                    status_pb.finish_with_message("❌ Unknown error occurred.");
+                    return Err(eyre::eyre!("Unknown error: {}", error));
+                }
+            }
+        }
+
+        if let Some(access_token) = token_resp["access_token"].as_str() {
+            // Save token to config
+            let config_dir = dirs::home_dir()
+                .ok_or_else(|| eyre::eyre!("Could not determine home directory"))?
+                .join(".config")
+                .join("bountybot");
+            fs::create_dir_all(&config_dir)?;
+
+            let config_path = config_dir.join("config.toml");
+            let config_content = format!("github_token = \"{access_token}\"");
+            fs::write(config_path, config_content)?;
+
+            status_pb.finish_with_message("✨ Successfully logged in!");
+            return Ok(access_token.to_string());
+        }
+    }
+} 

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -22,10 +22,7 @@ pub async fn login(client_id: &str) -> eyre::Result<String> {
     let device_code_resp = client
         .post("https://github.com/login/device/code")
         .header("Accept", "application/json")
-        .form(&[
-            ("client_id", client_id),
-            ("scope", "repo"),
-        ])
+        .form(&[("client_id", client_id), ("scope", "repo")])
         .send()
         .await?
         .error_for_status()?
@@ -101,4 +98,4 @@ pub async fn login(client_id: &str) -> eyre::Result<String> {
             return Ok(access_token.to_string());
         }
     }
-} 
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,12 +1,13 @@
 use crate::{Cli, RepoIssue};
 use clap::CommandFactory;
 use clap_complete::Shell;
-use eyre::WrapErr;
-use git2::{Cred, PushOptions, RemoteCallbacks, Repository};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use octocrab::Octocrab;
-use std::time::Duration;
-use tracing::{debug, instrument};
+use tracing::debug;
+
+mod login;
+mod start;
+
+/// Default GitHub App client ID for bountybot
+static CLIENT_ID: &str = "Ov23liQIMCvcASsBifc1";
 
 #[derive(clap::Subcommand, Debug)]
 /// Start of Selection
@@ -30,22 +31,61 @@ pub enum Command {
         #[arg(value_enum)]
         shell: Shell,
     },
+
+    /// Login to GitHub using device flow
+    #[command(name = "login", aliases = ["l"])]
+    Login {
+        /// The GitHub App's client ID
+        #[arg(long, env = "GITHUB_CLIENT_ID", default_value = CLIENT_ID)]
+        client_id: String,
+    },
 }
 
-#[instrument(skip(github_token))]
-pub async fn handle(command: Command, github_token: &str) -> eyre::Result<()> {
+impl Command {
+    /// Returns true if this command requires authentication
+    const fn requires_auth(&self) -> bool {
+        matches!(self, Self::Start { .. })
+    }
+}
+
+/// Handle the command execution
+/// 
+/// # Arguments
+/// * `command` - The command to execute
+/// * `github_token` - Optional GitHub token for authentication
+///
+/// # Returns
+/// * `eyre::Result<()>` - Result of the command execution
+///
+/// # Panics
+/// * When unwrapping the GitHub token in the Start command, which is safe because we check for token presence before execution
+pub async fn handle(command: Command, github_token: Option<&str>) -> eyre::Result<()> {
     debug!(?command, "handling bounty command");
+
+    // Convert input token to owned string if present
+    let mut token = github_token.map(String::from);
+
+    // If command requires auth and we don't have a token, trigger login flow
+    if command.requires_auth() && token.is_none() {
+        println!("This command requires authentication.\n");
+        token = Some(login::login(CLIENT_ID).await?);
+    }
+
     match command {
         Command::Start { issue_ref } => {
             let repo_issue = RepoIssue::parse(&issue_ref)?;
-            start_bounty(
+            // We can safely unwrap here because we either have a token or would have returned above
+            start::start_bounty(
                 &format!("{}/{}", repo_issue.owner, repo_issue.repo),
                 repo_issue.issue_number,
-                github_token,
+                &token.unwrap(),
             )
             .await?;
         }
         Command::Completion { shell } => completion(shell),
+        Command::Login { client_id } => {
+            let _token = login::login(&client_id).await?;
+        }
     }
     Ok(())
 }
@@ -54,139 +94,4 @@ fn completion(shell: Shell) {
     let mut cmd = Cli::command();
     let name = cmd.get_name().to_string();
     clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
-}
-
-#[instrument(skip(github_token), fields(owner, repo))]
-async fn start_bounty(
-    repo_full_name: &str,
-    issue_number: u64,
-    github_token: &str,
-) -> eyre::Result<()> {
-    let (owner, repo) = repo_full_name
-        .split_once('/')
-        .ok_or_else(|| eyre::eyre!("Invalid repo format. Expected 'owner/repo'"))?;
-
-    // Set span fields after we have the values
-    tracing::Span::current().record("owner", owner);
-    tracing::Span::current().record("repo", repo);
-
-    let multi = MultiProgress::new();
-    let spinner_style = ProgressStyle::with_template("{spinner:.green} {msg:.bold.dim}")
-        .unwrap()
-        .tick_chars("⣾⣽⣻⢿⡿⣟⣯⣷");
-
-    let status_pb = multi.add(ProgressBar::new_spinner());
-    status_pb.set_style(spinner_style);
-    status_pb.enable_steady_tick(Duration::from_millis(80));
-
-    status_pb.set_message(format!(
-        "Starting work on bounty for {owner}/{repo}#{issue_number}"
-    ));
-
-    debug!("initializing GitHub client");
-    let octocrab = Octocrab::builder()
-        .personal_token(github_token.to_string())
-        .build()
-        .wrap_err("failed to initialize GitHub client")?;
-
-    status_pb.set_message("Creating fork of repository...");
-    let fork = octocrab
-        .repos(owner, repo)
-        .create_fork()
-        .send()
-        .await
-        .wrap_err("failed to create fork")?;
-
-    debug!(?fork.owner, "fork created/exists");
-    let fork_owner = fork.owner.unwrap().login;
-    status_pb.set_message("✓ Fork created successfully");
-
-    // Clone the repository
-    let repo_url = format!("https://github.com/{fork_owner}/{repo}.git");
-    let temp_dir = tempfile::tempdir()?;
-    status_pb.set_message("Cloning repository...");
-
-    let mut callbacks = RemoteCallbacks::new();
-    callbacks.credentials(|_url, _username_from_url, _allowed_types| {
-        Cred::userpass_plaintext("git", github_token)
-    });
-
-    let mut fetch_options = git2::FetchOptions::new();
-    let mut fetch_callbacks = RemoteCallbacks::new();
-    fetch_callbacks.credentials(|_url, _username_from_url, _allowed_types| {
-        Cred::userpass_plaintext("git", github_token)
-    });
-    fetch_options.remote_callbacks(fetch_callbacks);
-
-    let git_repo =
-        Repository::clone(&repo_url, temp_dir.path()).wrap_err("failed to clone repository")?;
-
-    // Create and checkout new branch
-    let branch_name = format!("issue-{issue_number}");
-    status_pb.set_message(format!("Creating branch {branch_name}..."));
-
-    let head = git_repo.head()?.peel_to_commit()?;
-    git_repo.branch(&branch_name, &head, false)?;
-
-    // Create empty commit
-    let sig = git_repo.signature()?;
-    let tree_id = head.tree_id();
-    let tree = git_repo.find_tree(tree_id)?;
-
-    git_repo.commit(
-        Some(&format!("refs/heads/{branch_name}")),
-        &sig,
-        &sig,
-        &format!("Start work on #{issue_number}"),
-        &tree,
-        &[&head],
-    )?;
-
-    // Push the branch
-    status_pb.set_message("Pushing branch...");
-    let mut remote = git_repo.find_remote("origin")?;
-    let mut push_options = PushOptions::new();
-    push_options.remote_callbacks(callbacks);
-
-    remote.push(
-        &[&format!(
-            "refs/heads/{branch_name}:refs/heads/{branch_name}"
-        )],
-        Some(&mut push_options),
-    )?;
-
-    // Get repository info to find default branch
-    status_pb.set_message("Getting repository info...");
-    let repo_info = octocrab
-        .repos(owner, repo)
-        .get()
-        .await
-        .wrap_err("failed to get repository info")?;
-
-    let default_branch = repo_info
-        .default_branch
-        .unwrap_or_else(|| "main".to_string());
-
-    // Create draft PR
-    status_pb.set_message("Creating draft pull request...");
-    let pr = octocrab
-        .pulls(owner, repo)
-        .create(
-            format!("WIP: Fix #{issue_number}"),
-            format!("{fork_owner}:{branch_name}"),
-            default_branch,
-        )
-        .draft(true)
-        .send()
-        .await
-        .wrap_err("failed to create pull request")?;
-
-    status_pb.finish_with_message(format!("✨ Ready to work on issue #{issue_number}"));
-
-    // Print final status in a clean way
-    println!("\n🔗 Issue: https://github.com/{owner}/{repo}/issues/{issue_number}");
-    println!("🌿 Branch: https://github.com/{fork_owner}/{repo}/tree/{branch_name}");
-    println!("📝 Pull Request: {}", pr.html_url.unwrap());
-
-    Ok(())
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -49,7 +49,7 @@ impl Command {
 }
 
 /// Handle the command execution
-/// 
+///
 /// # Arguments
 /// * `command` - The command to execute
 /// * `github_token` - Optional GitHub token for authentication

--- a/src/command/start.rs
+++ b/src/command/start.rs
@@ -153,4 +153,4 @@ pub async fn start_bounty(
     println!("📝 Pull Request: {}", pr.html_url.unwrap());
 
     Ok(())
-} 
+}

--- a/src/command/start.rs
+++ b/src/command/start.rs
@@ -1,0 +1,156 @@
+use eyre::WrapErr;
+use git2::{Cred, PushOptions, RemoteCallbacks, Repository};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use octocrab::Octocrab;
+use std::time::Duration;
+use tracing::{debug, instrument};
+
+#[instrument(skip(github_token), fields(owner, repo))]
+pub async fn start_bounty(
+    repo_full_name: &str,
+    issue_number: u64,
+    github_token: &str,
+) -> eyre::Result<()> {
+    let (owner, repo) = repo_full_name
+        .split_once('/')
+        .ok_or_else(|| eyre::eyre!("Invalid repo format. Expected 'owner/repo'"))?;
+
+    // Set span fields after we have the values
+    tracing::Span::current().record("owner", owner);
+    tracing::Span::current().record("repo", repo);
+
+    let multi = MultiProgress::new();
+    let spinner_style = ProgressStyle::with_template("{spinner:.green} {msg:.bold.dim}")
+        .unwrap()
+        .tick_chars("⣾⣽⣻⢿⡿⣟⣯⣷");
+
+    let status_pb = multi.add(ProgressBar::new_spinner());
+    status_pb.set_style(spinner_style);
+    status_pb.enable_steady_tick(Duration::from_millis(80));
+
+    status_pb.set_message(format!(
+        "Starting work on bounty for {owner}/{repo}#{issue_number}"
+    ));
+
+    debug!("initializing GitHub client");
+    let octocrab = Octocrab::builder()
+        .personal_token(github_token.to_string())
+        .build()
+        .wrap_err("failed to initialize GitHub client")?;
+
+    status_pb.set_message("Creating fork of repository...");
+    let fork = octocrab
+        .repos(owner, repo)
+        .create_fork()
+        .send()
+        .await
+        .wrap_err("failed to create fork")?;
+
+    debug!(?fork.owner, "fork created/exists");
+    let fork_owner = fork.owner.unwrap().login;
+    status_pb.set_message("✓ Fork created successfully");
+
+    // Clone the repository
+    let repo_url = format!("https://github.com/{fork_owner}/{repo}.git");
+    let temp_dir = tempfile::tempdir()?;
+    status_pb.set_message("Cloning repository...");
+
+    let mut callbacks = RemoteCallbacks::new();
+    callbacks.credentials(|_url, _username_from_url, _allowed_types| {
+        Cred::userpass_plaintext("git", github_token)
+    });
+
+    let mut fetch_options = git2::FetchOptions::new();
+    let mut fetch_callbacks = RemoteCallbacks::new();
+    fetch_callbacks.credentials(|_url, _username_from_url, _allowed_types| {
+        Cred::userpass_plaintext("git", github_token)
+    });
+    fetch_options.remote_callbacks(fetch_callbacks);
+
+    let git_repo =
+        Repository::clone(&repo_url, temp_dir.path()).wrap_err("failed to clone repository")?;
+
+    // Create and checkout new branch
+    let branch_name = format!("issue-{issue_number}");
+    status_pb.set_message(format!("Creating branch {branch_name}..."));
+
+    let head = git_repo.head()?.peel_to_commit()?;
+    git_repo.branch(&branch_name, &head, false)?;
+
+    // Create empty commit
+    let sig = git_repo.signature()?;
+    let tree_id = head.tree_id();
+    let tree = git_repo.find_tree(tree_id)?;
+
+    git_repo.commit(
+        Some(&format!("refs/heads/{branch_name}")),
+        &sig,
+        &sig,
+        &format!("Start work on #{issue_number}"),
+        &tree,
+        &[&head],
+    )?;
+
+    // Push the branch
+    status_pb.set_message("Pushing branch...");
+    let mut remote = git_repo.find_remote("origin")?;
+    let mut push_options = PushOptions::new();
+    push_options.remote_callbacks(callbacks);
+
+    remote.push(
+        &[&format!(
+            "+refs/heads/{branch_name}:refs/heads/{branch_name}"
+        )],
+        Some(&mut push_options),
+    )?;
+
+    // Get repository info to find default branch
+    status_pb.set_message("Getting repository info...");
+    let repo_info = octocrab
+        .repos(owner, repo)
+        .get()
+        .await
+        .wrap_err("failed to get repository info")?;
+
+    let default_branch = repo_info
+        .default_branch
+        .unwrap_or_else(|| "main".to_string());
+
+    // Check if PR already exists
+    status_pb.set_message("Checking for existing pull requests...");
+    let existing_prs = octocrab
+        .pulls(owner, repo)
+        .list()
+        .head(format!("{fork_owner}:{branch_name}"))
+        .send()
+        .await
+        .wrap_err("failed to check for existing pull requests")?;
+
+    let pr = if let Some(existing_pr) = existing_prs.items.first() {
+        status_pb.set_message("Found existing pull request");
+        existing_pr.clone()
+    } else {
+        // Create draft PR
+        status_pb.set_message("Creating draft pull request...");
+        octocrab
+            .pulls(owner, repo)
+            .create(
+                format!("WIP: Fix #{issue_number}"),
+                format!("{fork_owner}:{branch_name}"),
+                default_branch,
+            )
+            .draft(true)
+            .send()
+            .await
+            .wrap_err("failed to create pull request")?
+    };
+
+    status_pb.finish_with_message(format!("✨ Ready to work on issue #{issue_number}"));
+
+    // Print final status in a clean way
+    println!("\n🔗 Issue: https://github.com/{owner}/{repo}/issues/{issue_number}");
+    println!("🌿 Branch: https://github.com/{fork_owner}/{repo}/tree/{branch_name}");
+    println!("📝 Pull Request: {}", pr.html_url.unwrap());
+
+    Ok(())
+} 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,15 +22,17 @@ impl Config {
         Ok(config)
     }
 
-    pub fn get_github_token(&self) -> Result<String> {
-        // Then try environment variable
-        let token = self
-            .github_token
-            .clone()
-            .or_else(|| std::env::var("GITHUB_TOKEN").ok())
-            .ok_or_else(|| eyre::eyre!("GitHub token not found in config file or environment"))?;
+    /// Try to get the GitHub token from config file or environment
+    /// Returns None if no token is found
+    #[must_use]
+    pub fn try_get_github_token(&self) -> Option<String> {
+        self.github_token.clone().or_else(|| std::env::var("GITHUB_TOKEN").ok())
+    }
 
-        Ok(token)
+    /// Get the GitHub token, returning an error if not found
+    pub fn get_github_token(&self) -> Result<String> {
+        self.try_get_github_token()
+            .ok_or_else(|| eyre::eyre!("GitHub token not found in config file or environment"))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,9 @@ impl Config {
     /// Returns None if no token is found
     #[must_use]
     pub fn try_get_github_token(&self) -> Option<String> {
-        self.github_token.clone().or_else(|| std::env::var("GITHUB_TOKEN").ok())
+        self.github_token
+            .clone()
+            .or_else(|| std::env::var("GITHUB_TOKEN").ok())
     }
 
     /// Get the GitHub token, returning an error if not found

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,8 @@ async fn main() -> eyre::Result<()> {
 async fn run() -> eyre::Result<()> {
     let cli = Cli::parse();
     let config = config::Config::load()?;
-    let token = config.get_github_token()?;
+    let token = config.try_get_github_token();
 
-    bounty::command::handle(cli.command, &token).await?;
+    bounty::command::handle(cli.command, token.as_deref()).await?;
     Ok(())
 }


### PR DESCRIPTION
Add support for `bounty login`, which uses the [GitHub Device Tokens](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps) to retrieve a personal token for the user.

If the user uses a command that requires authentication, we send them through this flow automatically.

Resolves #6 